### PR TITLE
Update unified sdk to v7.1.0

### DIFF
--- a/bolos-sys/sdk/fetch_sdk.sh
+++ b/bolos-sys/sdk/fetch_sdk.sh
@@ -12,10 +12,10 @@
 
 # Nano X
 : "${BOLOS_SDK_X_PATH:=nanox-secure-sdk}"
-: "${BOLOS_SDK_X_GIT_TAG:=v1.2.1}"
+: "${BOLOS_SDK_X_GIT_TAG:=v7.1.0}"
 # Nano S+
 : "${BOLOS_SDK_SP_PATH:=nanosplus-secure-sdk}"
-: "${BOLOS_SDK_SP_GIT_TAG:=v1.2.1}"
+: "${BOLOS_SDK_SP_GIT_TAG:=v7.1.0}"
 
 echo "Checkout S SDK & update in $BOLOS_SDK_S_PATH from $BOLOS_SDK_S_GIT $BOLOS_SDK_S_GIT_HASH"
 git submodule add --force "$BOLOS_SDK_S_GIT" "$BOLOS_SDK_S_PATH" || true


### PR DESCRIPTION
unified sdk version update to v7.1.0 using an older version causes compilation errors when compiling the btc integration into avax.

<!-- ClickUpRef: 8677uw48j -->
:link: [zboto Link](https://app.clickup.com/t/8677uw48j)