### PR TITLE
chore: declare custom cfg names and silence bindgen transmute lint

### DIFF
--- a/bolos-derive/build.rs
+++ b/bolos-derive/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=BOLOS_SDK");
+    println!("cargo::rustc-check-cfg=cfg(bolos_sdk)");
 
     if let Some(v) = std::env::var_os("BOLOS_SDK") {
         if !v.is_empty() {

--- a/bolos-impl/build.rs
+++ b/bolos-impl/build.rs
@@ -21,6 +21,11 @@ fn detect_device() -> Option<Device> {
 fn main() {
     println!("cargo:rerun-if-env-changed=TARGET_NAME");
     println!("cargo:rerun-if-env-changed=BOLOS_SDK");
+    println!("cargo::rustc-check-cfg=cfg(bolos_sdk)");
+    println!("cargo::rustc-check-cfg=cfg(nanos)");
+    println!("cargo::rustc-check-cfg=cfg(nanox)");
+    println!("cargo::rustc-check-cfg=cfg(nanosplus)");
+    println!("cargo::rustc-check-cfg=cfg(stax)");
 
     if let Some(v) = env::var_os("BOLOS_SDK") {
         if !v.is_empty() {

--- a/bolos-mock/build.rs
+++ b/bolos-mock/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=BOLOS_SDK");
+    println!("cargo::rustc-check-cfg=cfg(bolos_sdk)");
 
     if let Some(v) = std::env::var_os("BOLOS_SDK") {
         if !v.is_empty() {

--- a/bolos-sys/build.rs
+++ b/bolos-sys/build.rs
@@ -80,6 +80,11 @@ fn detect_device() -> Option<Device> {
 fn main() {
     println!("cargo:rerun-if-env-changed=BOLOS_SDK");
     println!("cargo:rerun-if-env-changed=TARGET_NAME");
+    println!("cargo::rustc-check-cfg=cfg(bolos_sdk)");
+    println!("cargo::rustc-check-cfg=cfg(nanos)");
+    println!("cargo::rustc-check-cfg=cfg(nanox)");
+    println!("cargo::rustc-check-cfg=cfg(nanosplus)");
+    println!("cargo::rustc-check-cfg=cfg(stax)");
 
     if let Some(v) = env::var_os("BOLOS_SDK") {
         if !v.is_empty() {

--- a/bolos-sys/src/lib.rs
+++ b/bolos-sys/src/lib.rs
@@ -32,6 +32,8 @@ pub mod raw {
     #![allow(non_camel_case_types)]
     #![allow(dead_code)]
     #![allow(clippy::upper_case_acronyms)]
+    #![allow(unknown_lints)]
+    #![allow(unnecessary_transmutes)]
 
     #[cfg(any(nanos, nanox, nanosplus, stax))]
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/bolos/build.rs
+++ b/bolos/build.rs
@@ -1,5 +1,8 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=BOLOS_SDK");
+    println!("cargo::rustc-check-cfg=cfg(bolos_sdk)");
+    println!("cargo::rustc-check-cfg=cfg(__impl)");
+    println!("cargo::rustc-check-cfg=cfg(__mock)");
 
     if let Some(v) = std::env::var_os("BOLOS_SDK") {
         if !v.is_empty() {

--- a/zemu/build.rs
+++ b/zemu/build.rs
@@ -21,6 +21,14 @@ fn detect_device() -> Option<Device> {
 fn main() {
     println!("cargo:rerun-if-env-changed=BOLOS_SDK");
     println!("cargo:rerun-if-env-changed=TARGET_NAME");
+    println!("cargo::rustc-check-cfg=cfg(bolos_sdk)");
+    println!("cargo::rustc-check-cfg=cfg(nanos)");
+    println!("cargo::rustc-check-cfg=cfg(nanox)");
+    println!("cargo::rustc-check-cfg=cfg(nanosplus)");
+    println!("cargo::rustc-check-cfg=cfg(stax)");
+    println!("cargo::rustc-check-cfg=cfg(zemu_sdk)");
+    println!("cargo::rustc-check-cfg=cfg(zemu_logging)");
+    println!("cargo::rustc-check-cfg=cfg(revamped_io)");
 
     if let Some(v) = env::var_os("BOLOS_SDK") {
         if !v.is_empty() {


### PR DESCRIPTION
Rust 1.80+ warns on cfg names that aren't declared via check-cfg, and
rust 1.88's `unnecessary_transmutes` lint fires on bindgen output. Both
caused noisy builds (300+ warnings). Declare all custom cfgs from
each crate's build.rs and allow the transmute lint inside the
auto-generated `raw` module.
